### PR TITLE
Free security descriptor to avoid leak

### DIFF
--- a/PPLdump/exploit.cpp
+++ b/PPLdump/exploit.cpp
@@ -780,6 +780,11 @@ BOOL FindFileForTransaction(_In_ DWORD dwMinSize, _Out_ LPWSTR* ppwszFilePath)
 								bReturnValue = TRUE;
 							}
 						}
+						if (NULL != pSD)
+						{
+						    LocalFree(pSD);
+							pSD = NULL;
+						}
 					}
 				}
 
@@ -799,7 +804,7 @@ BOOL WritePayloadDllTransacted(_Out_ PHANDLE pdhFile)
 {
 	//
 	// This implementation was inspired by the DLL Hollowing technique, discussed by @_ForrestOrr
-	// in this blog post: Masking Malicious Memory Artifacts – Part I: Phantom DLL Hollowing
+	// in this blog post: Masking Malicious Memory Artifacts Â– Part I: Phantom DLL Hollowing
 	// https://www.forrest-orr.net/post/malicious-memory-artifacts-part-i-dll-hollowing
 	// This trick is awesome! :)
 	//


### PR DESCRIPTION
The security descriptor returned from GetSecurityInfo needs to be freed by the caller: 

https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-getsecurityinfo
> A pointer to a variable that receives a pointer to the security descriptor of the object. When you have finished using the pointer, free the returned buffer by calling the LocalFree function.